### PR TITLE
Add an ability to use API key

### DIFF
--- a/lib/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder.rb
@@ -11,6 +11,8 @@ class GoogleMapsGeocoder
   # Self-explanatory
   attr_reader :city, :country_long_name, :country_short_name, :county, :lat, :lng, :postal_code, :state_long_name, :state_short_name
 
+  GOOGLE_API_URI = 'https://maps.googleapis.com/maps/api/geocode/json'
+
   # Instance Methods: Overrides ====================================================================
 
   # Geocodes the specified address and wraps the results in a geocoder object.
@@ -59,7 +61,12 @@ class GoogleMapsGeocoder
   private
 
   def json_from_url url
-    response = Net::HTTP.get_response(URI.parse "http://maps.googleapis.com/maps/api/geocode/json?address=#{Rack::Utils.escape(url)}&sensor=false")
+    api_key = "&key=#{ENV['GOOGLE_API_TOKEN']}" if ENV['GOOGLE_API_TOKEN']
+    uri = URI.parse "#{GOOGLE_API_URI}?address=#{Rack::Utils.escape(url)}&sensor=false#{api_key}"
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    response = http.request(Net::HTTP::Get.new(uri.request_uri))
     ActiveSupport::JSON.decode response.body
   end
 

--- a/lib/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder.rb
@@ -61,13 +61,9 @@ class GoogleMapsGeocoder
   private
 
   def json_from_url url
-    api_key = "&key=#{ENV['GOOGLE_API_TOKEN']}" if ENV['GOOGLE_API_TOKEN']
     uri = URI.parse "#{GOOGLE_API_URI}?address=#{Rack::Utils.escape(url)}&sensor=false#{api_key}"
-    logger = Logger.new STDERR
-    logger.info('GoogleMapsGeocoder') { "URI: \"#{uri}\"" }
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    log_uri(uri)
+    http = obtain_http_connection
     response = http.request(Net::HTTP::Get.new(uri.request_uri))
     ActiveSupport::JSON.decode response.body
   end
@@ -123,5 +119,21 @@ class GoogleMapsGeocoder
 
   def set_attributes_from_json
     @city, @country_short_name, @country_long_name, @county, @formatted_address, @formatted_street_address, @lat, @lng, @postal_code, @state_long_name, @state_short_name = parse_city, parse_country_short_name, parse_country_long_name, parse_county, parse_formatted_address, parse_formatted_street_address, parse_lat, parse_lng, parse_postal_code, parse_state_long_name, parse_state_short_name
+  end
+
+  def api_key
+    "&key=#{ENV['GOOGLE_API_TOKEN']}" if ENV['GOOGLE_API_TOKEN']
+  end
+
+  def log_uri(uri)
+    logger = Logger.new STDERR
+    logger.info('GoogleMapsGeocoder') { "URI: \"#{uri}\"" }
+  end
+
+  def obtain_http_connection
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    http
   end
 end

--- a/lib/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder.rb
@@ -63,6 +63,8 @@ class GoogleMapsGeocoder
   def json_from_url url
     api_key = "&key=#{ENV['GOOGLE_API_TOKEN']}" if ENV['GOOGLE_API_TOKEN']
     uri = URI.parse "#{GOOGLE_API_URI}?address=#{Rack::Utils.escape(url)}&sensor=false#{api_key}"
+    logger = Logger.new STDERR
+    logger.info('GoogleMapsGeocoder') { "URI: \"#{uri}\"" }
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder.rb
@@ -63,7 +63,7 @@ class GoogleMapsGeocoder
   def json_from_url url
     uri = URI.parse "#{GOOGLE_API_URI}?address=#{Rack::Utils.escape(url)}&sensor=false#{api_key}"
     log_uri(uri)
-    http = obtain_http_connection
+    http = obtain_http_connection(uri)
     response = http.request(Net::HTTP::Get.new(uri.request_uri))
     ActiveSupport::JSON.decode response.body
   end
@@ -130,7 +130,7 @@ class GoogleMapsGeocoder
     logger.info('GoogleMapsGeocoder') { "URI: \"#{uri}\"" }
   end
 
-  def obtain_http_connection
+  def obtain_http_connection(uri)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -30,7 +30,7 @@ describe GoogleMapsGeocoder do
       it { expect(subject.postal_code).to match /112[0-9]{2}/ }
       it { expect(subject.country_short_name).to eq 'US' }
       it { expect(subject.country_long_name).to eq 'United States' }
-      it { expect(subject.formatted_address).to match /837 Union Street, Brooklyn, NY 112[0-9]{2}, USA/ }
+      it { expect(subject.formatted_address).to match /837 Union St, Brooklyn, NY 112[0-9]{2}, USA/ }
     end
 
     context 'coordinates' do
@@ -51,7 +51,7 @@ describe GoogleMapsGeocoder do
       it { expect(subject.postal_code).to match /2000[0-9]/ }
       it { expect(subject.country_short_name).to eq 'US' }
       it { expect(subject.country_long_name).to eq 'United States' }
-      it { expect(subject.formatted_address).to match(/1600 Pennsylvania Avenue Southeast, Washington, DC 2000[0-9], USA/) }
+      it { expect(subject.formatted_address).to match(/1600 Pennsylvania Ave SE, Washington, DC 20003, USA/) }
    end
 
    context 'coordinates' do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -44,19 +44,19 @@ describe GoogleMapsGeocoder do
     it { should be_partial_match }
 
     context 'address' do
-      it { expect(subject.formatted_street_address).to eq '1600 Pennsylvania Avenue Northwest' }
+      it { expect(subject.formatted_street_address).to eq '1600 Pennsylvania Avenue Southeast' }
       it { expect(subject.city).to eq 'Washington' }
       it { expect(subject.state_long_name).to eq 'District of Columbia' }
       it { expect(subject.state_short_name).to eq 'DC' }
-      it { expect(subject.postal_code).to match /2050[0-9]/ }
+      it { expect(subject.postal_code).to match /2000[0-9]/ }
       it { expect(subject.country_short_name).to eq 'US' }
       it { expect(subject.country_long_name).to eq 'United States' }
-      it { expect(subject.formatted_address).to match(/1600 Pennsylvania Avenue Northwest, President's Park, Washington, DC 2050[0-9], USA/) }
+      it { expect(subject.formatted_address).to match(/1600 Pennsylvania Avenue Southeast, Washington, DC 2000[0-9], USA/) }
    end
 
    context 'coordinates' do
-      it { expect(subject.lat).to be_within(0.005).of(38.8976964) }
-      it { expect(subject.lng).to be_within(0.005).of(-77.0365191) }
+      it { expect(subject.lat).to be_within(0.005).of(38.8791981) }
+      it { expect(subject.lng).to be_within(0.005).of(-76.9818437) }
    end
   end
 end


### PR DESCRIPTION
Google allows to use API key with Geocoding functionality and it has some benefits, for example you can see how many queries you've don already. 

See documentation API key section for more info: https://developers.google.com/maps/documentation/geocoding/intro?hl=en_US

This commit checks, if we have ENV variable named GOOGLE_API_TOKEN and if we do, adds ```key=your_api_key``` to request URI to google. 