### PR TITLE
Add explicit error when google returns non-OK status

### DIFF
--- a/lib/google_maps_geocoder/google_maps_geocoder_error_handler.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder_error_handler.rb
@@ -1,0 +1,17 @@
+# Handling errors form Google
+module GoogleMapsGeocoderErrorHandler
+  # Parent class for more concrete errors
+  class GeneralGoecodingError < StandardError
+    def initialize(response_json = '')
+      @json = response_json
+      super
+    end
+
+    def message
+      "Google returned:\n#{@json.inspect}"
+    end
+  end
+
+  class ZeroResultsError < GeneralGoecodingError; end
+  class QueryLimitError < GeneralGoecodingError; end
+end

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -81,4 +81,25 @@ describe GoogleMapsGeocoder do
       )
     end
   end
+
+  context 'with google returns empty results' do
+    let(:empty_result) { { 'results' => [], 'status' => 'ZERO_RESULTS' } }
+    let(:limit_result) { { 'results' => [], 'status' => 'OVER_QUERY_LIMIT' } }
+
+    it 'raises an error if we have empty results' do
+      allow_any_instance_of(GoogleMapsGeocoder).to receive(:json_from_url)\
+        .and_return empty_result
+
+      expect { GoogleMapsGeocoder.new('anything') }.to \
+        raise_error(GoogleMapsGeocoderErrorHandler::ZeroResultsError)
+    end
+
+    it 'raises an error if we have qery limit exceed' do
+      allow_any_instance_of(GoogleMapsGeocoder).to receive(:json_from_url)\
+        .and_return limit_result
+
+      expect { GoogleMapsGeocoder.new('anything') }.to \
+        raise_error(GoogleMapsGeocoderErrorHandler::QueryLimitError)
+    end
+  end
 end


### PR DESCRIPTION
  before this we were returning "exceeded query limit" error on any non-OK status from Google, which looks confusing when we are trying to deal with this errors in our app.

  This change add separate error class (inherinted from standard error) which simply returns responce from Google if we had non-OK status.

  Have place for futher concretezation for error-types (for example, we might have `GoogleMapsGeocoderEmptyResponseError` or `GoogleMapsGeocoderQueryLimitError`, but for now it's just a general `GoogleMapsGeocoderError` which can be handled on the app's side