### PR TITLE
Simplify error handling

### DIFF
--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -27,7 +27,7 @@ class GoogleMapsGeocoder
     #
     # @param json [Hash] Google Maps' JSON response
     # @return [GeocodingError] the geocoding error
-    def initialize(json = '')
+    def initialize(json = {})
       @json = json
       super @json['status']
     end

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -106,8 +106,8 @@ class GoogleMapsGeocoder
       ENV['GOOGLE_MAPS_API_KEY']
   end
 
-  def google_maps_request(query)
-    "#{GOOGLE_MAPS_API}?address=#{Rack::Utils.escape query}&sensor=false"\
+  def google_maps_request(address)
+    "#{GOOGLE_MAPS_API}?address=#{Rack::Utils.escape address}&sensor=false"\
     "#{google_maps_api_key}"
   end
 

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -77,7 +77,7 @@ describe GoogleMapsGeocoder do
       end
     end
   end
-  describe '#query_url' do
+  describe '#google_maps_request' do
     context "when ENV['GOOGLE_MAPS_API_KEY'] = 'MY_API_KEY'" do
       before { ENV['GOOGLE_MAPS_API_KEY'] = 'MY_API_KEY' }
 
@@ -86,7 +86,7 @@ describe GoogleMapsGeocoder do
       subject { @exact_match }
 
       it do
-        expect(subject.send(:query_url, nil)).to eq(
+        expect(subject.send(:google_maps_request, nil)).to eq(
           'https://maps.googleapis.com/maps/api/geocode/json?address='\
           '&sensor=false&key=MY_API_KEY'
         )

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -17,80 +17,79 @@ describe GoogleMapsGeocoder do
     pending 'waiting for query limit to pass' if @query_limit
   end
 
-  context 'with "837 Union Street Brooklyn NY"' do
-    subject { @exact_match }
+  describe '#new' do
+    context 'with "837 Union Street Brooklyn NY"' do
+      subject { @exact_match }
 
-    it { expect(subject).to be_exact_match }
+      it { expect(subject).to be_exact_match }
 
-    context 'address' do
-      it { expect(subject.formatted_street_address).to eq '837 Union Street' }
-      it { expect(subject.city).to eq 'Brooklyn' }
-      it { expect(subject.county).to match(/Kings/) }
-      it { expect(subject.state_long_name).to eq 'New York' }
-      it { expect(subject.state_short_name).to eq 'NY' }
-      it { expect(subject.postal_code).to match(/112[0-9]{2}/) }
-      it { expect(subject.country_short_name).to eq 'US' }
-      it { expect(subject.country_long_name).to eq 'United States' }
-      it do
-        expect(subject.formatted_address)
-          .to match(/837 Union St, Brooklyn, NY 112[0-9]{2}, USA/)
+      context 'address' do
+        it { expect(subject.formatted_street_address).to eq '837 Union Street' }
+        it { expect(subject.city).to eq 'Brooklyn' }
+        it { expect(subject.county).to match(/Kings/) }
+        it { expect(subject.state_long_name).to eq 'New York' }
+        it { expect(subject.state_short_name).to eq 'NY' }
+        it { expect(subject.postal_code).to match(/112[0-9]{2}/) }
+        it { expect(subject.country_short_name).to eq 'US' }
+        it { expect(subject.country_long_name).to eq 'United States' }
+        it do
+          expect(subject.formatted_address)
+            .to match(/837 Union St, Brooklyn, NY 112[0-9]{2}, USA/)
+        end
+      end
+      context 'coordinates' do
+        it { expect(subject.lat).to be_within(0.005).of(40.6748151) }
+        it { expect(subject.lng).to be_within(0.005).of(-73.9760302) }
       end
     end
-    context 'coordinates' do
-      it { expect(subject.lat).to be_within(0.005).of(40.6748151) }
-      it { expect(subject.lng).to be_within(0.005).of(-73.9760302) }
-    end
-  end
+    context 'with "1600 Pennsylvania Washington"' do
+      subject { @partial_match }
 
-  context 'with "1600 Pennsylvania Washington"' do
-    subject { @partial_match }
+      it { should be_partial_match }
 
-    it { should be_partial_match }
-
-    context 'address' do
-      it do
-        expect(subject.formatted_street_address)
-          .to eq '1600 Pennsylvania Avenue Northwest'
+      context 'address' do
+        it do
+          expect(subject.formatted_street_address)
+            .to eq '1600 Pennsylvania Avenue Northwest'
+        end
+        it { expect(subject.city).to eq 'Washington' }
+        it { expect(subject.state_long_name).to eq 'District of Columbia' }
+        it { expect(subject.state_short_name).to eq 'DC' }
+        it { expect(subject.postal_code).to eq '20500' }
+        it { expect(subject.country_short_name).to eq 'US' }
+        it { expect(subject.country_long_name).to eq 'United States' }
+        it do
+          expect(subject.formatted_address)
+            .to match(/1600 Pennsylvania Ave NW, Washington, DC 20500, USA/)
+        end
       end
-      it { expect(subject.city).to eq 'Washington' }
-      it { expect(subject.state_long_name).to eq 'District of Columbia' }
-      it { expect(subject.state_short_name).to eq 'DC' }
-      it { expect(subject.postal_code).to eq '20500' }
-      it { expect(subject.country_short_name).to eq 'US' }
-      it { expect(subject.country_long_name).to eq 'United States' }
-      it do
-        expect(subject.formatted_address)
-          .to match(/1600 Pennsylvania Ave NW, Washington, DC 20500, USA/)
+      context 'coordinates' do
+        it { expect(subject.lat).to be_within(0.005).of(38.8976633) }
+        it { expect(subject.lng).to be_within(0.005).of(-77.0365739) }
       end
     end
-    context 'coordinates' do
-      it { expect(subject.lat).to be_within(0.005).of(38.8976633) }
-      it { expect(subject.lng).to be_within(0.005).of(-77.0365739) }
+    context 'with an invalid address' do
+      subject { GoogleMapsGeocoder.new('Four score and seven years ago') }
+
+      it do
+        expect { subject }.to raise_error GoogleMapsGeocoder::GeocodingError,
+                                          'ZERO_RESULTS'
+      end
     end
   end
+  describe '#query_url' do
+    context "when ENV['GOOGLE_MAPS_API_KEY'] = 'MY_API_KEY'" do
+      before { ENV['GOOGLE_MAPS_API_KEY'] = 'MY_API_KEY' }
 
-  context "when ENV['GOOGLE_MAPS_API_KEY'] = 'INVALID_KEY'" do
-    before { ENV['GOOGLE_MAPS_API_KEY'] = 'INVALID_KEY' }
+      after { ENV['GOOGLE_MAPS_API_KEY'] = nil }
 
-    subject { @exact_match }
+      subject { @exact_match }
 
-    it do
-      expect(subject.send(:query_url, nil)).to eq(
-        'https://maps.googleapis.com/maps/api/geocode/json?address='\
-        '&sensor=false&key=INVALID_KEY'
-      )
-    end
-  end
-
-  context 'with google returns empty results' do
-    let(:results_hash) { { 'results' => [] } }
-
-    GoogleMapsGeocoder::ERROR_STATUSES.each do |key, value|
-      it "raises #{key} error" do
-        allow_any_instance_of(GoogleMapsGeocoder).to receive(:json_from_url)
-          .and_return results_hash.merge('status' => value)
-        expect { GoogleMapsGeocoder.new('anything') }
-          .to raise_error(GoogleMapsGeocoder.send(:error_class_name, key))
+      it do
+        expect(subject.send(:query_url, nil)).to eq(
+          'https://maps.googleapis.com/maps/api/geocode/json?address='\
+          '&sensor=false&key=MY_API_KEY'
+        )
       end
     end
   end


### PR DESCRIPTION
1. Reduce error classes to `GeocodingError`, which wraps the JSON response.
2. Rename method names, arguments, and constants for clarity and relatedness.