### PR TITLE
sys: bumped to 0.6.1

### DIFF
--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
 
-  s.add_runtime_dependency 'activesupport', '~> 4.2'
   s.add_runtime_dependency 'rack', '~> 1.6'
+  s.add_runtime_dependency 'activesupport', '~> 4.1', '>= 4.1.11'
 
   s.files       = `git ls-files`.split "\n"
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split "\n"

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls', '~> 0'
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rubocop', '~> 0'
+  s.add_development_dependency 'rubocop', '~> 0.49.0'
 
   s.add_runtime_dependency 'activesupport', '~> 4.2'
   s.add_runtime_dependency 'rack', '~> 1.6'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
 
-  s.add_runtime_dependency 'rack', '~> 1.6'
   s.add_runtime_dependency 'activesupport', '~> 4.1', '>= 4.1.11'
+  s.add_runtime_dependency 'rack', '~> 1.5', '>= 1.5.4'
 
   s.files       = `git ls-files`.split "\n"
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split "\n"

--- a/lib/google_maps_geocoder/version.rb
+++ b/lib/google_maps_geocoder/version.rb
@@ -1,4 +1,4 @@
 # A simple PORO wrapper for geocoding with Google Maps.
 class GoogleMapsGeocoder
-  VERSION = '0.6.0'.freeze unless defined?(GoogleMapsGeocoder::VERSION)
+  VERSION = '0.6.1'.freeze unless defined?(GoogleMapsGeocoder::VERSION)
 end


### PR DESCRIPTION
# Goal
Fix security warnings.

# Approach
1. Fix [activesupport](https://hakiri.io/github/ivanoblomov/google_maps_geocoder/master/8f2a35c78bec10ef2eb20c0ead32dfe64490381d/warnings?name=Attribute+Restriction).
2. Fix [rack](https://hakiri.io/github/ivanoblomov/google_maps_geocoder/master/8f2a35c78bec10ef2eb20c0ead32dfe64490381d/warnings?name=Denial+of+Service).
3. Fix [rubocop](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418).
