### PR TITLE
Support Geocoder's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The complete, hopefully self-explanatory, API is:
 For compatibility with [Geocoder](https://github.com/alexreisner/geocoder), the following aliases are also available:
 
 * `GoogleMapsGeocoder#address`
+* `GoogleMapsGeocoder#coordinates`
 * `GoogleMapsGeocoder#country`
 * `GoogleMapsGeocoder#country_code`
 * `GoogleMapsGeocoder#latitude`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ The complete, hopefully self-explanatory, API is:
 * `GoogleMapsGeocoder#state_long_name`
 * `GoogleMapsGeocoder#state_short_name`
 
+For compatibility with [Geocoder](https://github.com/alexreisner/geocoder), the following aliases are also available:
+
+* `GoogleMapsGeocoder#address`
+* `GoogleMapsGeocoder#country`
+* `GoogleMapsGeocoder#country_code`
+* `GoogleMapsGeocoder#latitude`
+* `GoogleMapsGeocoder#longitude`
+* `GoogleMapsGeocoder#state`
+* `GoogleMapsGeocoder#state_code`
+
 ## Google Maps API Key (Optional)
 
 To have GoogleMapsGeocoder use your Google Maps API key, set it as an environment variable:

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -21,6 +21,14 @@ class GoogleMapsGeocoder
     GOOGLE_ADDRESS_SEGMENTS + %i[formatted_address formatted_street_address]
   ).freeze
 
+  alias_method :address, :formatted_address
+  alias_method :country, :country_long_name
+  alias_method :country_code, :country_short_name
+  alias_method :latitude, :latitude
+  alias_method :longitude, :lng
+  alias_method :state, :state_long_name
+  alias_method :state_code, :state_short_name
+
   # Returns the complete formatted address with standardized abbreviations.
   #
   # @return [String] the complete formatted address
@@ -60,24 +68,9 @@ class GoogleMapsGeocoder
     end
   end
 
-  # Returns the formatted address as a comma-delimited string.
-  def address
-    formatted_address
-  end
-
   # Returns the address' coordinates as an array of floats.
   def coordinates
     [lat, lng]
-  end
-
-  # Returns the address' country as a full string.
-  def country
-    country_long_name
-  end
-
-  # Returns the address' country as an abbreviated string.
-  def country_code
-    country_short_name
   end
 
   # Returns true if the address Google returns is an exact match.
@@ -90,16 +83,6 @@ class GoogleMapsGeocoder
     !partial_match?
   end
 
-  # Returns the address' latitude as a float.
-  def latitude
-    lat
-  end
-
-  # Returns the address' longitude as a float.
-  def longitude
-    lng
-  end
-
   # Returns true if the address Google returns isn't an exact match.
   #
   # @return [boolean] whether the Google Maps result is a partial match
@@ -108,16 +91,6 @@ class GoogleMapsGeocoder
   #     => true
   def partial_match?
     @json['results'][0]['partial_match'] == true
-  end
-
-  # Returns the address' state as a full string.
-  def state
-    state_long_name
-  end
-
-  # Returns the address' state as an abbreviated string.
-  def state_code
-    state_short_name
   end
 
   # A geocoding error returned by Google Maps.

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -41,19 +41,19 @@ class GoogleMapsGeocoder
   attr_reader(*GOOGLE_ADDRESS_SEGMENTS)
 
   # Returns the formatted address as a comma-delimited string.
-  alias :address, :formatted_address
+  alias address, formatted_address
   # Returns the address' country as a full string.
-  alias :country, :country_long_name
+  alias country, country_long_name
   # Returns the address' country as an abbreviated string.
-  alias :country_code, :country_short_name
+  alias country_code, country_short_name
   # Returns the address' latitude as a float.
-  alias :latitude, :latitude
+  alias latitude, lat
   # Returns the address' longitude as a float.
-  alias :longitude, :lng
+  alias longitude, lng
   # Returns the address' state as a full string.
-  alias :state, :state_long_name
+  alias state, state_long_name
   # Returns the address' state as an abbreviated string.
-  alias :state_code, :state_short_name
+  alias state_code, state_short_name
 
   # Geocodes the specified address and wraps the results in a GoogleMapsGeocoder
   # object.

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -60,6 +60,26 @@ class GoogleMapsGeocoder
     end
   end
 
+  # Returns the formatted address as a comma-delimited string.
+  def address
+    formatted_address
+  end
+
+  # Returns the address' coordinates as an array of floats.
+  def coordinates
+    [lat, lng]
+  end
+
+  # Returns the address' country as a full string.
+  def country
+    country_long_name
+  end
+
+  # Returns the address' country as an abbreviated string.
+  def country_code
+    country_short_name
+  end
+
   # Returns true if the address Google returns is an exact match.
   #
   # @return [boolean] whether the Google Maps result is an exact match
@@ -70,6 +90,16 @@ class GoogleMapsGeocoder
     !partial_match?
   end
 
+  # Returns the address' latitude as a float.
+  def latitude
+    lat
+  end
+
+  # Returns the address' longitude as a float.
+  def longitude
+    lng
+  end
+
   # Returns true if the address Google returns isn't an exact match.
   #
   # @return [boolean] whether the Google Maps result is a partial match
@@ -78,6 +108,16 @@ class GoogleMapsGeocoder
   #     => true
   def partial_match?
     @json['results'][0]['partial_match'] == true
+  end
+
+  # Returns the address' state as a full string.
+  def state
+    state_long_name
+  end
+
+  # Returns the address' state as an abbreviated string.
+  def state_code
+    state_short_name
   end
 
   # A geocoding error returned by Google Maps.

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -41,19 +41,19 @@ class GoogleMapsGeocoder
   attr_reader(*GOOGLE_ADDRESS_SEGMENTS)
 
   # Returns the formatted address as a comma-delimited string.
-  alias address, formatted_address
+  alias address formatted_address
   # Returns the address' country as a full string.
-  alias country, country_long_name
+  alias country country_long_name
   # Returns the address' country as an abbreviated string.
-  alias country_code, country_short_name
+  alias country_code country_short_name
   # Returns the address' latitude as a float.
-  alias latitude, lat
+  alias latitude lat
   # Returns the address' longitude as a float.
-  alias longitude, lng
+  alias longitude lng
   # Returns the address' state as a full string.
-  alias state, state_long_name
+  alias state state_long_name
   # Returns the address' state as an abbreviated string.
-  alias state_code, state_short_name
+  alias state_code state_short_name
 
   # Geocodes the specified address and wraps the results in a GoogleMapsGeocoder
   # object.

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -41,19 +41,19 @@ class GoogleMapsGeocoder
   attr_reader(*GOOGLE_ADDRESS_SEGMENTS)
 
   # Returns the formatted address as a comma-delimited string.
-  alias_method :address, :formatted_address
+  alias :address, :formatted_address
   # Returns the address' country as a full string.
-  alias_method :country, :country_long_name
+  alias :country, :country_long_name
   # Returns the address' country as an abbreviated string.
-  alias_method :country_code, :country_short_name
+  alias :country_code, :country_short_name
   # Returns the address' latitude as a float.
-  alias_method :latitude, :latitude
+  alias :latitude, :latitude
   # Returns the address' longitude as a float.
-  alias_method :longitude, :lng
+  alias :longitude, :lng
   # Returns the address' state as a full string.
-  alias_method :state, :state_long_name
+  alias :state, :state_long_name
   # Returns the address' state as an abbreviated string.
-  alias_method :state_code, :state_short_name
+  alias :state_code, :state_short_name
 
   # Geocodes the specified address and wraps the results in a GoogleMapsGeocoder
   # object.

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -21,14 +21,6 @@ class GoogleMapsGeocoder
     GOOGLE_ADDRESS_SEGMENTS + %i[formatted_address formatted_street_address]
   ).freeze
 
-  alias_method :address, :formatted_address
-  alias_method :country, :country_long_name
-  alias_method :country_code, :country_short_name
-  alias_method :latitude, :latitude
-  alias_method :longitude, :lng
-  alias_method :state, :state_long_name
-  alias_method :state_code, :state_short_name
-
   # Returns the complete formatted address with standardized abbreviations.
   #
   # @return [String] the complete formatted address
@@ -47,6 +39,21 @@ class GoogleMapsGeocoder
   attr_reader :formatted_street_address
   # Self-explanatory
   attr_reader(*GOOGLE_ADDRESS_SEGMENTS)
+
+  # Returns the formatted address as a comma-delimited string.
+  alias_method :address, :formatted_address
+  # Returns the address' country as a full string.
+  alias_method :country, :country_long_name
+  # Returns the address' country as an abbreviated string.
+  alias_method :country_code, :country_short_name
+  # Returns the address' latitude as a float.
+  alias_method :latitude, :latitude
+  # Returns the address' longitude as a float.
+  alias_method :longitude, :lng
+  # Returns the address' state as a full string.
+  alias_method :state, :state_long_name
+  # Returns the address' state as an abbreviated string.
+  alias_method :state_code, :state_short_name
 
   # Geocodes the specified address and wraps the results in a GoogleMapsGeocoder
   # object.

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -42,6 +42,16 @@ describe GoogleMapsGeocoder do
         it { expect(subject.lat).to be_within(0.005).of(38.8976633) }
         it { expect(subject.lng).to be_within(0.005).of(-77.0365739) }
       end
+      context 'Geocoder API' do
+        it { expect(subject.address).to eq subject.formatted_address }
+        it { expect(subject.coordinates).to eq [subject.lat, subject.lng] }
+        it { expect(subject.country).to eq subject.country_long_name }
+        it { expect(subject.country_code).to eq subject.country_short_name }
+        it { expect(subject.latitude).to eq subject.lat }
+        it { expect(subject.longitude).to eq subject.lng }
+        it { expect(subject.state).to eq subject.state_long_name }
+        it { expect(subject.state_code).to eq subject.state_short_name }
+      end
     end
     context 'when API key is invalid' do
       before do


### PR DESCRIPTION
Closes: #18

# Goal
Support [`geocoder`'s API](https://github.com/alexreisner/geocoder#custom-result-handling) to facilitate migration.

# Approach
Add methods for:
1. `#address`
2. `#coordinates`
3. `#country`
4. `#country_code`
5. `#latitude`
6. `#longitude`
7. `#state`
8. `#state_code`