### PR TITLE
(chore) gemspec: HTTPS in homepage URL

### DIFF
--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.description = 'Geocode a location without worrying about parsing Google '\
                   "Maps' response. GoogleMapsGeocoder wraps it in a plain-old "\
                   'Ruby object.'
-  s.homepage = 'http://github.com/ivanoblomov/google_maps_geocoder'
+  s.homepage = 'https://github.com/ivanoblomov/google_maps_geocoder'
   s.authors = ['Roderick Monje']
   s.email = 'rod@foveacentral.com'
 


### PR DESCRIPTION
This PR updates the homepage URI to use `https`.

# Goal

Keep the metadata up-to-date.


# Approach
1. Edit in-place.
