### PR TITLE
README: Use only SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GoogleMapsGeocoder
 
 [![Build Status](https://secure.travis-ci.org/ivanoblomov/google_maps_geocoder.svg)](http://travis-ci.org/ivanoblomov/google_maps_geocoder)
-[![Code Climate](https://codeclimate.com/github/ivanoblomov/google_maps_geocoder.svg)](https://codeclimate.com/github/ivanoblomov/google_maps_geocoder)
+[![Code Climate](https://codeclimate.com/github/ivanoblomov/google_maps_geocoder.png)](https://codeclimate.com/github/ivanoblomov/google_maps_geocoder)
 [![Coverage Status](https://coveralls.io/repos/github/ivanoblomov/google_maps_geocoder/badge.svg?branch=master)](https://coveralls.io/github/ivanoblomov/google_maps_geocoder?branch=master)
 [![Inline docs](http://inch-ci.org/github/Ivanoblomov/google_maps_geocoder.svg?branch=master)](http://inch-ci.org/github/Ivanoblomov/google_maps_geocoder)
 [![Gem Version](https://badge.fury.io/rb/google_maps_geocoder.svg)](http://badge.fury.io/rb/google_maps_geocoder)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GoogleMapsGeocoder
 
-[![Build Status](https://secure.travis-ci.org/ivanoblomov/google_maps_geocoder.png)](http://travis-ci.org/ivanoblomov/google_maps_geocoder)
-[![Code Climate](https://codeclimate.com/github/ivanoblomov/google_maps_geocoder.png)](https://codeclimate.com/github/ivanoblomov/google_maps_geocoder)
+[![Build Status](https://secure.travis-ci.org/ivanoblomov/google_maps_geocoder.svg)](http://travis-ci.org/ivanoblomov/google_maps_geocoder)
+[![Code Climate](https://codeclimate.com/github/ivanoblomov/google_maps_geocoder.svg)](https://codeclimate.com/github/ivanoblomov/google_maps_geocoder)
 [![Coverage Status](https://coveralls.io/repos/github/ivanoblomov/google_maps_geocoder/badge.svg?branch=master)](https://coveralls.io/github/ivanoblomov/google_maps_geocoder?branch=master)
 [![Inline docs](http://inch-ci.org/github/Ivanoblomov/google_maps_geocoder.svg?branch=master)](http://inch-ci.org/github/Ivanoblomov/google_maps_geocoder)
 [![Gem Version](https://badge.fury.io/rb/google_maps_geocoder.svg)](http://badge.fury.io/rb/google_maps_geocoder)


### PR DESCRIPTION

This PR changes the build badges to SVG for sharper readability ✨

# Goal

For a uniform look

# Approach
1. Edit in-place. Preview rendered result.