### PR TITLE
CI: Add Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: false
 rvm:
   - 2.2.5
+  - 2.7
 script:
   - bundle exec rake
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 rvm:
-  - 2.2.5
-  - 2.7
+  - 2.2.10
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 script:
   - bundle exec rake
   - bundle exec rubocop


### PR DESCRIPTION

# Goal

Increase the knowledge we have about how this library runs with latest Ruby.


# Approach
1. add a 2.7 (an rvm alias)
2. drop unused directive sudo: false

This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
