### PR TITLE
Hakiri warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ export GOOGLE_MAPS_API_KEY=[your key]
 
 ## Copyright
 
-Copyright © 2011-2018 Roderick Monje. See [LICENSE.txt](https://github.com/ivanoblomov/google_maps_geocoder/blob/master/LICENSE.txt) for further details.
+Copyright © 2011-2020 Roderick Monje. See [LICENSE.txt](https://github.com/ivanoblomov/google_maps_geocoder/blob/master/LICENSE.txt) for further details.

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.49.0'
 
   s.add_runtime_dependency 'activesupport', '~> 3.2.22'
-  s.add_runtime_dependency 'rack', '~> 1.4.6'
+  s.add_runtime_dependency 'rack', '~> 1.6.11'
 
   s.files       = `git ls-files`.split "\n"
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split "\n"

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.49.0'
 
   s.add_runtime_dependency 'activesupport', '~> 3.2.22'
-  s.add_runtime_dependency 'rack', '~> 1.6.11'
+  s.add_runtime_dependency 'rack', '~> 2.1.3'
 
   s.files       = `git ls-files`.split "\n"
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split "\n"


### PR DESCRIPTION
# Goal
Address Hakiri's [critical warnings](https://hakiri.io/github/ivanoblomov/google_maps_geocoder/master/b77533ef8dd708d7fba9c7cc316aab58ba7887f8).

# Approach
1. Update `google_maps_geocoder.gemspec` with the recommended versions.

# Notes
Ignoring the [`activesupport` warning](https://hakiri.io/github/ivanoblomov/google_maps_geocoder/master/b77533ef8dd708d7fba9c7cc316aab58ba7887f8/warnings?name=Code+Injection) since we're not using any Rails caching.