### PR TITLE
Update to Rubocop < 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls', '~> 0'
   s.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rubocop', '~> 1.9'
+  s.add_development_dependency 'rubocop', '~> 1.8'
 
   s.add_runtime_dependency 'activesupport', '~> 4.1', '>= 4.1.11'
   s.add_runtime_dependency 'rack', '~> 2.1.4'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls', '~> 0'
   s.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rubocop', '~> 1.8'
+  s.add_development_dependency 'rubocop', '< 1.9'
 
   s.add_runtime_dependency 'activesupport', '~> 4.1', '>= 4.1.11'
   s.add_runtime_dependency 'rack', '~> 2.1.4'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('lib/google_maps_geocoder/version', __dir__)
 Gem::Specification.new do |s|
   s.name = 'google_maps_geocoder'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls', '~> 0'
   s.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rubocop', '~> 0.49.0'
+  s.add_development_dependency 'rubocop', '~> 1.9'
 
   s.add_runtime_dependency 'activesupport', '~> 4.1', '>= 4.1.11'
   s.add_runtime_dependency 'rack', '~> 2.1.4'

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -149,7 +149,7 @@ class GoogleMapsGeocoder
 
   def parse_address_component_type(type, name = 'long_name')
     address_component = @json['results'][0]['address_components'].detect do |ac|
-      ac['types']&.include?(type)
+      ac['types'] && ac['types'].include?(type)
     end
     address_component && address_component[name]
   end

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support'
 require 'logger'
 require 'net/http'
@@ -15,7 +17,7 @@ class GoogleMapsGeocoder
     city country_long_name country_short_name county lat lng postal_code
     state_long_name state_short_name
   ].freeze
-  GOOGLE_MAPS_API = 'https://maps.googleapis.com/maps/api/geocode/json'.freeze
+  GOOGLE_MAPS_API = 'https://maps.googleapis.com/maps/api/geocode/json'
 
   ALL_ADDRESS_SEGMENTS = (
     GOOGLE_ADDRESS_SEGMENTS + %i[formatted_address formatted_street_address]
@@ -70,7 +72,7 @@ class GoogleMapsGeocoder
     raise GeocodingError, @json if @json.blank? || status != 'OK'
 
     set_attributes_from_json
-    Logger.new(STDERR).info('GoogleMapsGeocoder') do
+    Logger.new($stderr).info('GoogleMapsGeocoder') do
       "Geocoded \"#{address}\" => \"#{formatted_address}\""
     end
   end
@@ -119,7 +121,7 @@ class GoogleMapsGeocoder
     def initialize(json = {})
       @json = json
       if (message = @json['error_message'])
-        Logger.new(STDERR).error(message)
+        Logger.new($stderr).error(message)
       end
       super @json['status']
     end
@@ -147,7 +149,7 @@ class GoogleMapsGeocoder
 
   def parse_address_component_type(type, name = 'long_name')
     address_component = @json['results'][0]['address_components'].detect do |ac|
-      ac['types'] && ac['types'].include?(type)
+      ac['types']&.include?(type)
     end
     address_component && address_component[name]
   end

--- a/lib/google_maps_geocoder/version.rb
+++ b/lib/google_maps_geocoder/version.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 # A simple PORO wrapper for geocoding with Google Maps.
 class GoogleMapsGeocoder
-  VERSION = '0.7.3'.freeze unless defined?(GoogleMapsGeocoder::VERSION)
+  VERSION = '0.7.3' unless defined?(GoogleMapsGeocoder::VERSION)
 end

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -1,4 +1,6 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+# frozen_string_literal: true
+
+require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
   before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start
 require 'coveralls'


### PR DESCRIPTION
# Goal
Update to the latest version of Rubocop that has wide Ruby support, 1.8. Build was still using 0.49.

# Approach
1. Bump rubocop to < 1.9 (because latter requires ruby 2.4 and we want to provide as broad support as possible).
2. Run `bundle ex rubocop -A`.
