### PR TITLE
doc: removed hakiri badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Coverage Status](https://coveralls.io/repos/github/ivanoblomov/google_maps_geocoder/badge.svg?branch=master)](https://coveralls.io/github/ivanoblomov/google_maps_geocoder?branch=master)
 [![Inline docs](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder.svg?branch=master)](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder)
 [![Gem Version](https://badge.fury.io/rb/google_maps_geocoder.svg)](https://rubygems.org/gems/google_maps_geocoder)
-[![security](https://hakiri.io/github/ivanoblomov/google_maps_geocoder/master.svg)](https://hakiri.io/github/ivanoblomov/google_maps_geocoder/master)
 
 A simple Plain Old Ruby Object wrapper for geocoding with Google Maps.
 


### PR DESCRIPTION
Closes: #30 

# Goal
Remove Hakiri since integrating Dependabot made it obsolete: ac06707f6f978b1e875ed078ee0d8a55d5df8d4f.

# Approach
1. Remove badge.
2. Remove webhook.