### PR TITLE
fix: moved coveralls to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby-version: [2.4, 2.5, 2.6, 2.7, 3.0]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,7 @@ jobs:
       env:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config do |c|
+  c.report_with_single_file = true
+  c.single_report_path = 'coverage/lcov.info'
+end
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter
+  ]
+)
+SimpleCov.start('ruby')

--- a/.simplecov
+++ b/.simplecov
@@ -12,4 +12,4 @@ SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
     SimpleCov::Formatter::LcovFormatter
   ]
 )
-SimpleCov.start('ruby')
+SimpleCov.start

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.13'
-  s.add_development_dependency 'simplecov', '~> 0.17'
+  s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.13'
-  s.add_development_dependency 'simplecov', '~> 0.16'
+  s.add_development_dependency 'simplecov', '~> 0.20'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.13'
+  s.add_development_dependency 'simplecov', '~> 0.21'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.13'
-  s.add_development_dependency 'simplecov', '~> 0.20'
+  s.add_development_dependency 'simplecov', '~> 0.18'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.13'
-  s.add_development_dependency 'simplecov', '~> 0.18'
+  s.add_development_dependency 'simplecov', '~> 0.21'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.13'
-  s.add_development_dependency 'simplecov', '~> 0.21'
+  s.add_development_dependency 'simplecov', '~> 0.18'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
   s.email = 'rod@foveacentral.com'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 1'
-  s.add_development_dependency 'coveralls', '~> 0'
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.13'
+  s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'
   s.add_runtime_dependency 'rack', '>= 2.1.4', '< 2.3.0'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.13'
-  s.add_development_dependency 'simplecov', '~> 0.21'
+  s.add_development_dependency 'simplecov', '~> 0.17'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'simplecov'
 require 'rubygems'
 require 'bundler'
 begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-require 'simplecov'
-SimpleCov.start
-require 'coveralls'
-Coveralls.wear!
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  Coveralls::SimpleCov::Formatter
-)
 require 'rubygems'
 require 'bundler'
 begin


### PR DESCRIPTION
Closes: #42

# Goal
Fix Coveralls errors.

# Approach
1. Moved Coveralls call to GitHub workflow (same as [vaccine-notifier](https://github.com/ivanoblomov/vaccine-notifier)).
2. Removed Ruby 2.2, 2.3 due to incompatibilities with `simplecov`. We're still supporting the last five Ruby releases without them.