### PR TITLE
CI: added rubocop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,5 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Rubocop
+      run: bundle ex rubocop

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -1,3 +1,4 @@
+# rubocop:disable Gemspec/RequiredRubyVersion
 # frozen_string_literal: true
 
 require File.expand_path('lib/google_maps_geocoder/version', __dir__)
@@ -29,3 +30,4 @@ Gem::Specification.new do |s|
                                          .map { |f| File.basename f }
   s.require_paths = ['lib']
 end
+# rubocop:enable Gemspec/RequiredRubyVersion

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -149,7 +149,7 @@ class GoogleMapsGeocoder
 
   def parse_address_component_type(type, name = 'long_name')
     address_component = @json['results'][0]['address_components'].detect do |ac|
-      ac['types'] && ac['types'].include?(type)
+      ac['types']&.include?(type)
     end
     address_component && address_component[name]
   end


### PR DESCRIPTION
# Goal
Add rubocop to CI.

# Approach
1. Run bundle ex rubocop in test.yml.
2. Run `rubocop -A` after [verified failure](https://github.com/ivanoblomov/google_maps_geocoder/runs/2206001541).
3. Disable `Gemspec/RequiredRubyVersion` cop since we don't want to dictate it.