### PR TITLE
fix: rubocop warnings

### DIFF
--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'codeclimate-test-reporter', '~> 1'
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rubocop', '< 1.13'
+  s.add_development_dependency 'rubocop', '< 1.14'
   s.add_development_dependency 'simplecov', '~> 0.18'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '< 1.14'
+  s.add_development_dependency 'rubocop-rake', '~> 0'
+  s.add_development_dependency 'rubocop-rspec', '~> 2'
   s.add_development_dependency 'simplecov', '~> 0.18'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -4,11 +4,13 @@ require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
   before(:all) do
-    @exact_match = GoogleMapsGeocoder.new('White House')
-  rescue SocketError
-    @no_network  = true
-  rescue RuntimeError
-    @query_limit = true
+    begin
+      @exact_match = GoogleMapsGeocoder.new('White House')
+    rescue SocketError
+      @no_network  = true
+    rescue RuntimeError
+      @query_limit = true
+    end
   end
 
   before(:each) do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -4,13 +4,11 @@ require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
   before(:all) do
-    begin
-      @exact_match = GoogleMapsGeocoder.new('White House')
-    rescue SocketError
-      @no_network  = true
-    rescue RuntimeError
-      @query_limit = true
-    end
+    @exact_match = GoogleMapsGeocoder.new('White House')
+  rescue SocketError
+    @no_network  = true
+  rescue RuntimeError
+    @query_limit = true
   end
 
   before(:each) do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -4,6 +4,7 @@ require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
   before(:all) do
+    # rubocop:disable Style/RedundantBegin
     begin
       @exact_match = GoogleMapsGeocoder.new('White House')
     rescue SocketError
@@ -11,6 +12,7 @@ describe GoogleMapsGeocoder do
     rescue RuntimeError
       @query_limit = true
     end
+    # rubocop:enable Style/RedundantBegin
   end
 
   before(:each) do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -4,7 +4,7 @@ require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
   before(:all) do
-    # rubocop:disable Style/RedundantBegin
+    # rubocop:disable Lint/RedundantCopDisableDirective, Style/RedundantBegin
     begin
       @exact_match = GoogleMapsGeocoder.new('White House')
     rescue SocketError
@@ -12,7 +12,7 @@ describe GoogleMapsGeocoder do
     rescue RuntimeError
       @query_limit = true
     end
-    # rubocop:enable Style/RedundantBegin
+    # rubocop:enable Lint/RedundantCopDisableDirective, Style/RedundantBegin
   end
 
   before(:each) do


### PR DESCRIPTION
# Goal
Fix rubocop warnings.

# Approach
1. Bumped `rubocop`.
2. Added recommended gems:
    1. `rubocop-rake`
    2. `rubocop-rspec`
3. `rubocop -A`