### PR TITLE
conf: require >= ruby 2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby-version: [2.5, 2.6, 2.7, 3.0]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split "\n"
   s.executables = `git ls-files -- bin/*`.split("\n")
                                          .map { |f| File.basename f }
-  s.required_ruby_version = ['>= 2.4', '>= 2.5', '>= 2.6', '>= 2.7', '>= 3.0']
   s.require_paths = ['lib']
 end
 # rubocop:enable Gemspec/RequiredRubyVersion

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -1,4 +1,3 @@
-# rubocop:disable Gemspec/RequiredRubyVersion
 # frozen_string_literal: true
 
 require File.expand_path('lib/google_maps_geocoder/version', __dir__)
@@ -30,6 +29,6 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split "\n"
   s.executables = `git ls-files -- bin/*`.split("\n")
                                          .map { |f| File.basename f }
+  s.required_ruby_version = '>= 2.4'
   s.require_paths = ['lib']
 end
-# rubocop:enable Gemspec/RequiredRubyVersion

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -1,4 +1,3 @@
-# rubocop:disable Gemspec/RequiredRubyVersion
 # frozen_string_literal: true
 
 require File.expand_path('lib/google_maps_geocoder/version', __dir__)
@@ -31,5 +30,5 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n")
                                          .map { |f| File.basename f }
   s.require_paths = ['lib']
+  s.required_ruby_version = '>= 2.5'
 end
-# rubocop:enable Gemspec/RequiredRubyVersion

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split "\n"
   s.executables = `git ls-files -- bin/*`.split("\n")
                                          .map { |f| File.basename f }
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = ['>= 2.4', '>= 2.5', '>= 2.6', '>= 2.7', '>= 3.0']
   s.require_paths = ['lib']
 end

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -1,3 +1,4 @@
+# rubocop:disable Gemspec/RequiredRubyVersion
 # frozen_string_literal: true
 
 require File.expand_path('lib/google_maps_geocoder/version', __dir__)
@@ -32,3 +33,4 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ['>= 2.4', '>= 2.5', '>= 2.6', '>= 2.7', '>= 3.0']
   s.require_paths = ['lib']
 end
+# rubocop:enable Gemspec/RequiredRubyVersion


### PR DESCRIPTION
# Goal
Fix [`required_ruby_version` failure](https://github.com/ivanoblomov/google_maps_geocoder/runs/4175164372?check_suite_focus=true) in master.

# Approach
Require the [minimum supported Ruby version](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-4-10-released/): 2.5.