### PR TITLE
CII silver: project oversight

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,27 +29,8 @@ This is a developer's certification that he or she has the right to
 submit the patch for inclusion into the project.
 
 Simply submitting a contribution implies this agreement, however,
-please include a "Signed-off-by" tag in every patch
+please include a "Signed-off-by" tag in the PR
 (this tag is a conventional way to confirm that you agree to the DCO).
-You can do this with <tt>git commit --signoff</tt> (the <tt>-s</tt> flag
-is a synonym for <tt>--signoff</tt>).
-
-Another way to do this is to write the following at the end of the commit
-message, on a line by itself separated by a blank line from the body of
-the commit:
-
-````
-Signed-off-by: YOUR NAME <YOUR.EMAIL@EXAMPLE.COM>
-````
-
-You can signoff by default in this project by creating a file
-(say "git-template") that contains
-some blank lines and the signed-off-by text above;
-then configure git to use that as a commit template.  For example:
-
-````sh
-git config commit.template ~/cii-best-practices-badge/git-template
-````
 
 It's not practical to fix old contributions in git, so if one is forgotten,
 do not try to fix them.  We presume that if someone sometimes used a DCO,

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,4 +19,40 @@
 
 4. [Open a pull request](https://github.com/ivanoblomov/google_maps_geocoder/compare) with the patch or feature. Follow the template's directions.
 
+## Developer Certificate of Origin (DCO)
+
+All contributions (including pull requests) must agree to
+the [Developer Certificate of Origin (DCO) version 1.1](doc/dco.txt).
+This is exactly the same one created and used by the Linux kernel developers
+and posted on <http://developercertificate.org/>.
+This is a developer's certification that he or she has the right to
+submit the patch for inclusion into the project.
+
+Simply submitting a contribution implies this agreement, however,
+please include a "Signed-off-by" tag in every patch
+(this tag is a conventional way to confirm that you agree to the DCO).
+You can do this with <tt>git commit --signoff</tt> (the <tt>-s</tt> flag
+is a synonym for <tt>--signoff</tt>).
+
+Another way to do this is to write the following at the end of the commit
+message, on a line by itself separated by a blank line from the body of
+the commit:
+
+````
+Signed-off-by: YOUR NAME <YOUR.EMAIL@EXAMPLE.COM>
+````
+
+You can signoff by default in this project by creating a file
+(say "git-template") that contains
+some blank lines and the signed-off-by text above;
+then configure git to use that as a commit template.  For example:
+
+````sh
+git config commit.template ~/cii-best-practices-badge/git-template
+````
+
+It's not practical to fix old contributions in git, so if one is forgotten,
+do not try to fix them.  We presume that if someone sometimes used a DCO,
+a commit without a DCO is an accident and the DCO still applies.
+
 ## Thanks for contributing!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,5 @@ What problem does this pull request solve? This should be close to the goal of t
     1. This will help code reviewers get oriented quickly.
     2. It will also document for future maintainers exactly what changed (and why) when this PR was merged.
 2. **Add specs** that either *reproduce the bug* or *cover the new feature*. In the former's case, *make sure it fails without the fix!*
+
+Signed-off-by: YOUR NAME <YOUR.EMAIL@EXAMPLE.COM>

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ For compatibility with [Geocoder](https://github.com/alexreisner/geocoder), the 
 * `GoogleMapsGeocoder#state`
 * `GoogleMapsGeocoder#state_code`
 
-## [Contributing to GoogleMapsGeocoder](https://github.com/ivanoblomov/google_maps_geocoder/blob/master/.github/CONTRIBUTING.md)
-
 ## Documentation
 
 Complete RDoc documentation is available at [RubyDoc.info](https://www.rubydoc.info/gems/google_maps_geocoder).
+
+## [Contributing to GoogleMapsGeocoder](https://github.com/ivanoblomov/google_maps_geocoder/blob/master/.github/CONTRIBUTING.md)
 
 ## Cheers!
 


### PR DESCRIPTION
Re: #63

# Goal
Add Developer Certificate of Origin.

# Approach
1. Adapt CII Best Practices' [DCO](https://github.com/coreinfrastructure/best-practices-badge/blob/main/CONTRIBUTING.md).
2. Add `Signed-off-by` tag to PR template (instead of every commit message).