### PR TITLE
CI: remove duplicate key with

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         oidc: true
         files: coverage/lcov.info
-      with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - run: bundle exec rubocop
     - run: bundle exec inch --pedantic


### PR DESCRIPTION
# Closes: #202

## Goal
Fix fatal test-action error in master.

## Approach
1. Delete extra `with`.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
