### PR TITLE
CI: test library against latest rubies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Ruby ${{ matrix.ruby-version }}
     strategy:
       matrix:
-        ruby-version: [3.1, 3.2, 3.3]
+        ruby-version: [3.3, 3.4, 4.0]
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'inch'
+gem 'logger'
 gem 'pry'
 gem 'rake'
 gem 'rspec'


### PR DESCRIPTION
# Closes: n/a

## Goal
Test library against [Ruby's supported releases](https://endoflife.date/ruby).

## Approach
1. Bump test matrix `ruby-version` in `test.yml`.
2. Install `logger` since Ruby 4 omits it from standard lib.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
